### PR TITLE
ramips: update dts for LibreRouter R2 with new partition layout

### DIFF
--- a/target/linux/ramips/dts/mt7621_librerouter_librerouter-r2.dts
+++ b/target/linux/ramips/dts/mt7621_librerouter_librerouter-r2.dts
@@ -34,52 +34,47 @@
 };
 
 &spi0 {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <44000000>;
-		broken-flash-reset;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x0 0x30000>;
-				read-only;
-			};
-
-			partition@30000 {
-				label = "u-boot-env";
-				reg = <0x30000 0x1000>;
-			};
-
-			factory: partition@40000 {
-				label = "factory";
-				reg = <0x40000 0x10000>;
-				read-only;
-			};
-
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x50000 0x1000000>;
-			};
-
-			partition@1500000 {
-				compatible = "denx,uimage";
-				label = "fw2";
-				reg = <0x1500000 0x1000000>;
-			};
-		};
-	};
+    status = "okay";
+    flash@0 {
+        compatible = "jedec,spi-nor";
+        reg = <0>;
+        spi-max-frequency = <44000000>;
+        broken-flash-reset;
+        partitions {
+            compatible = "fixed-partitions";
+            #address-cells = <1>;
+            #size-cells = <1>;
+            partition@0 {
+                label = "u-boot";
+                reg = <0x0 0x30000>;
+                read-only;
+            };
+            partition@30000 {
+                label = "u-boot-env";
+                reg = <0x30000 0x1000>;
+            };
+            partition@31000 {
+                label = "dummy";
+                reg = <0x31000 0xF000>;
+            };
+            factory: partition@40000 {
+                label = "factory";
+                reg = <0x40000 0x10000>;
+                read-only;
+            };
+            partition@50000 {
+                compatible = "denx,uimage";
+                label = "firmware";
+                reg = <0x50000 0xFA0000>; /* 16064KB (15.7MB) */
+            };
+            partition@FF0000 {
+                compatible = "denx,uimage";
+                label = "fw2";
+                reg = <0xFF0000 0xFA0000>; /* 16064KB (15.7MB) */
+            };
+        };
+    };
 };
-
-
 
 
 &gmac1 {


### PR DESCRIPTION
Fix fw partitions to have the same size
Fix uboot env to match uboot expected partition size
Add dummy partition to explicitly allocate free space and prevent factory relocation (used to enable ethernet initialization)
